### PR TITLE
Set logMessage Default Value to string.Empty 

### DIFF
--- a/da-bot/EventTypeMapping.cs
+++ b/da-bot/EventTypeMapping.cs
@@ -1,9 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace da_bot
 {
     public class EventTypeMapping

--- a/da-bot/EventTypeMapping.cs
+++ b/da-bot/EventTypeMapping.cs
@@ -1,8 +1,8 @@
-namespace da_bot
+﻿namespace da_bot
 {
     public class EventTypeMapping
     {
-        public string LogMessage { get; set; }
+        public string LogMessage { get; set; } = String.Empty;
         public LogEventType LogEventType { get; set; }
     }
 }


### PR DESCRIPTION
TIL that .Net 6 enabled Null Reference Checking by default. We will need
to be cautious when working with auto properties like we used here.

For more context:
https://stackoverflow.com/questions/67505347/non-nullable-property-must-contain-a-non-null-value-when-exiting-constructor-co