### PR TITLE
Replace Should with FluentAssertions

### DIFF
--- a/da-bot-unitTests/LogEventTypeDetectorTests/ShouldReportDeath.cs
+++ b/da-bot-unitTests/LogEventTypeDetectorTests/ShouldReportDeath.cs
@@ -1,4 +1,4 @@
-﻿using Should;
+﻿using FluentAssertions;
 
 namespace da_bot_unitTests.LogEventTypeDetectorTests
 {
@@ -17,13 +17,13 @@ namespace da_bot_unitTests.LogEventTypeDetectorTests
         [TestMethod]
         public void ShouldBeDeath()
         {
-            Result.ShouldEqual(da_bot.LogEventType.Death);
+            Result.Should().Be(da_bot.LogEventType.Death);
         }
 
         [TestMethod]
         public void ShouldNotBeUnknown()
         {
-            Result.ShouldNotEqual(da_bot.LogEventType.Unknown);
+            Result.Should().NotBe(da_bot.LogEventType.Unknown);
         }
     }
 }

--- a/da-bot-unitTests/LogEventTypeDetectorTests/ShouldReportLogin.cs
+++ b/da-bot-unitTests/LogEventTypeDetectorTests/ShouldReportLogin.cs
@@ -1,4 +1,4 @@
-﻿using Should;
+﻿using FluentAssertions;
 
 namespace da_bot_unitTests.LogEventTypeDetectorTests
 {
@@ -17,13 +17,13 @@ namespace da_bot_unitTests.LogEventTypeDetectorTests
         [TestMethod]
         public void ShouldBeConnected()
         {
-            Result.ShouldEqual(da_bot.LogEventType.Connected);
+            Result.Should().Be(da_bot.LogEventType.Connected);
         }
 
         [TestMethod]
         public void ShouldNotBeUnknown()
         {
-            Result.ShouldNotEqual(da_bot.LogEventType.Unknown);
+            Result.Should().NotBe(da_bot.LogEventType.Unknown);
         }
     }
 }

--- a/da-bot-unitTests/LogEventTypeDetectorTests/ShouldReportServerStarted.cs
+++ b/da-bot-unitTests/LogEventTypeDetectorTests/ShouldReportServerStarted.cs
@@ -1,4 +1,4 @@
-﻿using Should;
+﻿using FluentAssertions;
 
 namespace da_bot_unitTests.LogEventTypeDetectorTests
 {
@@ -17,13 +17,13 @@ namespace da_bot_unitTests.LogEventTypeDetectorTests
         [TestMethod]
         public void ShouldBeStarted()
         {
-            Result.ShouldEqual(da_bot.LogEventType.ServerStarted);
+            Result.Should().Be(da_bot.LogEventType.ServerStarted);
         }
 
         [TestMethod]
         public void ShouldNotBeUnknown()
         {
-            Result.ShouldNotEqual(da_bot.LogEventType.Unknown);
+            Result.Should().NotBe(da_bot.LogEventType.Unknown);
         }
     }
 }

--- a/da-bot-unitTests/da-bot-unitTests.csproj
+++ b/da-bot-unitTests/da-bot-unitTests.csproj
@@ -10,12 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
-    <PackageReference Include="Should" Version="1.1.20" />
-    <PackageReference Include="ShouldFluent" Version="1.1.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/da-bot/Program.cs
+++ b/da-bot/Program.cs
@@ -48,7 +48,7 @@ using (StreamReader reader = new StreamReader(new FileStream(latestFile.FullName
         reader.BaseStream.Seek(lastMaxOffset, SeekOrigin.Begin);
 
         //read out of the file until the EOF
-        string line = "";
+        string? line = "";
         while ((line = reader.ReadLine()) != null)
         {
             var logEventType = eventDetector.Detect(line);


### PR DESCRIPTION
The Should and ShouldFluent libraries haven't been updated since 2013.
Swapping it our for a new library called FluentAssertions. It doesn't
seem that different from Should.  It actually seems to have some
improvements.

Link:
https://fluentassertions.com/introduction