### PR TITLE
[Bug Fix] Display Player Name on Death

### DIFF
--- a/da-bot-unitTests/LogEventTypeDetectorTests/ShouldReportDeath.cs
+++ b/da-bot-unitTests/LogEventTypeDetectorTests/ShouldReportDeath.cs
@@ -25,5 +25,12 @@ namespace da_bot_unitTests.LogEventTypeDetectorTests
         {
             Result.Should().NotBe(da_bot.LogEventType.Unknown);
         }
+
+        [TestMethod]
+        public void ShouldExtractName()
+        {
+            var deathPlayerName = testString.Split(":").First().Split(" ")[4];
+            deathPlayerName.Should().Be("Diggforbeer");
+        }
     }
 }

--- a/da-bot/Services/LogFileLocatorService.cs
+++ b/da-bot/Services/LogFileLocatorService.cs
@@ -61,7 +61,7 @@ namespace da_bot.Services
                                 break;
                             case LogEventType.Death:
                                 Console.WriteLine($"{logEventType} - {line}");
-                                var deathPlayerName = line.Split(":").First().Split(" ").Last();
+                                var deathPlayerName = line.Split(":").First().Split(" ")[4];
                                 _discordService.PostMessage(text: $"{deathPlayerName} has died");
                                 break;
                             case LogEventType.ServerStarted:


### PR DESCRIPTION
The player name was not displayed correctly. It was showing an integer
rather than a string with the player name.